### PR TITLE
Run job with content

### DIFF
--- a/client/src/main/scala/pme123/adapters/client/ClientConfigDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/ClientConfigDialog.scala
@@ -13,7 +13,7 @@ private[client] case class ClientConfigDialog(context: String)
   // **************************
   @dom
   private[client] def showDetail(): Binding[HTMLElement] =
-    <div class="ui modal">
+    <div class="ui modal detailDialog">
       {ServerServices(context).clientConfigs().bind}{//
       detailHeader.bind}{//
       clientsTable.bind}

--- a/client/src/main/scala/pme123/adapters/client/ClientWebsocket.scala
+++ b/client/src/main/scala/pme123/adapters/client/ClientWebsocket.scala
@@ -25,7 +25,7 @@ case class ClientWebsocket(context: String)
       webSocket.value = Some(socket)
       info(s"Connect to Websocket: $path")
       socket.onmessage = {
-        (e: MessageEvent) =>
+        e: MessageEvent =>
           val message = Json.parse(e.data.toString)
           message.validate[AdapterMsg] match {
             case JsSuccess(AdapterRunning(logReport), _) =>
@@ -58,15 +58,15 @@ case class ClientWebsocket(context: String)
               errors.foreach(e => error(e.toString))
           }
       }
-      socket.onerror = { (e: ErrorEvent) =>
+      socket.onerror = { e: ErrorEvent =>
         error(s"exception with websocket: ${e.message}!")
         socket.close(0, e.message)
       }
-      socket.onopen = { (_: Event) =>
+      socket.onopen = { _: Event =>
         info("websocket open!")
         UIStore.clearLogData()
       }
-      socket.onclose = { (e: CloseEvent) =>
+      socket.onclose = { e: CloseEvent =>
         info("closed socket" + e.reason)
         if (e.code != reconnectWSCode) {
           setTimeout(1000) {

--- a/client/src/main/scala/pme123/adapters/client/ClientWebsocket.scala
+++ b/client/src/main/scala/pme123/adapters/client/ClientWebsocket.scala
@@ -3,7 +3,7 @@ package pme123.adapters.client
 import com.thoughtworks.binding.Binding.Var
 import org.scalajs.dom.raw._
 import org.scalajs.dom.window
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 import pme123.adapters.shared.{AdapterMsg, RunJob, RunStarted, _}
 
 import scala.scalajs.js.timers.setTimeout
@@ -78,9 +78,13 @@ case class ClientWebsocket(context: String)
   }
 
   def runAdapter() {
+    runAdapter(None)
+  }
+
+  def runAdapter(payload: Option[JsValue]) {
     info("run Adapter")
     webSocket.value
-      .foreach(_.send(Json.toJson(RunJob())
+      .foreach(_.send(Json.toJson(RunJob(payload = payload))
         .toString()))
   }
 

--- a/client/src/main/scala/pme123/adapters/client/DefaultClient.scala
+++ b/client/src/main/scala/pme123/adapters/client/DefaultClient.scala
@@ -30,7 +30,8 @@ object DefaultClient {
                    , clientType: String): Unit = {
     ClientType.fromString(clientType) match {
       case JOB_PROCESS =>
-        JobProcessView(context, websocketPath).create()
+        val socket = ClientWebsocket(context)
+        JobProcessView(socket, context, websocketPath, DefaultRunJobDialog(socket)).create()
       case JOB_RESULTS =>
         DefaultView("there is no JobResults page defined").create()
       case CUSTOM_PAGE =>

--- a/client/src/main/scala/pme123/adapters/client/DefaultRunJobDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/DefaultRunJobDialog.scala
@@ -1,0 +1,26 @@
+package pme123.adapters.client
+
+import com.thoughtworks.binding.{Binding, dom}
+import org.scalajs.dom.raw.HTMLElement
+import pme123.adapters.shared.Logger
+
+trait RunJobDialog {
+  def create(): Binding[HTMLElement]
+}
+
+case class DefaultRunJobDialog(socket: ClientWebsocket)
+  extends RunJobDialog
+    with Logger {
+
+  @dom
+  def create(): Binding[HTMLElement] = {
+    val show = UIStore.uiState.showRunJobDialog.bind
+    if (show) {
+      socket.runAdapter()
+      info("Run Adapter")
+
+    }
+    <div></div>
+  }
+
+}

--- a/client/src/main/scala/pme123/adapters/client/JobConfigDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/JobConfigDialog.scala
@@ -12,7 +12,7 @@ private[client] case class JobConfigDialog(context: String)
   // **************************
   @dom
   private[client] def showDetail(): Binding[HTMLElement] =
-    <div class="ui modal">
+    <div class="ui modal detailDialog">
       {ServerServices(context).jobConfigs().bind}{//
       detailHeader.bind}{//
       jobsTable.bind}

--- a/client/src/main/scala/pme123/adapters/client/JobProcessHeader.scala
+++ b/client/src/main/scala/pme123/adapters/client/JobProcessHeader.scala
@@ -11,9 +11,7 @@ import scala.language.implicitConversions
 import scala.scalajs.js.Dynamic.{global => g}
 import scala.scalajs.js.timers.setTimeout
 
-private[client] case class JobProcessHeader(context: String
-                                            , websocketPath: String
-                                            , socket: ClientWebsocket)
+private[client] case class JobProcessHeader(socket: ClientWebsocket)
   extends ClientUtils {
 
   // 1. level of abstraction
@@ -119,7 +117,7 @@ private[client] case class JobProcessHeader(context: String
 
     <div class="ui item">
       <button class="ui basic icon button"
-              onclick={_: Event => socket.runAdapter()}
+              onclick={_: Event => UIStore.showRunJobDialog()}
               disabled={runDisabled}
               data:data-tooltip="Run the Adapter"
               data:data-position="bottom right">

--- a/client/src/main/scala/pme123/adapters/client/JobProcessHeader.scala
+++ b/client/src/main/scala/pme123/adapters/client/JobProcessHeader.scala
@@ -117,7 +117,10 @@ private[client] case class JobProcessHeader(socket: ClientWebsocket)
 
     <div class="ui item">
       <button class="ui basic icon button"
-              onclick={_: Event => UIStore.showRunJobDialog()}
+              onclick={_: Event => UIStore.showRunJobDialog()
+                setTimeout(200) {
+                  jQuery(".ui.modal").modal("show")
+                }}
               disabled={runDisabled}
               data:data-tooltip="Run the Adapter"
               data:data-position="bottom right">

--- a/client/src/main/scala/pme123/adapters/client/JobProcessView.scala
+++ b/client/src/main/scala/pme123/adapters/client/JobProcessView.scala
@@ -9,22 +9,24 @@ import pme123.adapters.shared.LogEntry
 import scala.language.implicitConversions
 import scala.scalajs.js.timers.setTimeout
 
-case class JobProcessView(context: String, websocketPath: String)
+case class JobProcessView(socket: ClientWebsocket
+                          , context: String
+                          , websocketPath: String
+                          , runJobDialog: RunJobDialog)
   extends AdaptersClient {
-
-  private lazy val socket = ClientWebsocket(context)
 
   @dom
   protected def render: Binding[HTMLElement] = {
     socket.connectWS(Some(websocketPath))
     <div>
-      {JobProcessHeader(context, websocketPath, socket).showHeader().bind}{//
+      {JobProcessHeader(socket).showHeader().bind}{//
       adapterContainer.bind}{//
       renderDetail.bind}{//
       renderLogEntryDetail.bind}{//
       renderJobConfigsDetail.bind}{//
       renderClientConfigsDetail.bind}{//
-      renderLastResultsDetail.bind}
+      renderLastResultsDetail.bind}{//
+      runJobDialog.create().bind}
     </div>
   }
 

--- a/client/src/main/scala/pme123/adapters/client/LastResultDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/LastResultDialog.scala
@@ -12,7 +12,7 @@ private[client] case class LastResultDialog()
   // **************************
   @dom
   private[client] def showDetail(): Binding[HTMLElement] =
-    <div class="ui modal">
+    <div class="ui modal detailDialog">
       {detailHeader.bind}{//
       resultsTable.bind}
     </div>

--- a/client/src/main/scala/pme123/adapters/client/LogEntryDetailDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/LogEntryDetailDialog.scala
@@ -12,7 +12,7 @@ private[client] case class LogEntryDetailDialog(logEntry: LogEntry)
   // **************************
   @dom
   private[client] def showDetail(): Binding[HTMLElement] =
-    <div class="ui modal">
+    <div class="ui modal detailDialog">
       <div class="content">
         {jsLocalDateTime(logEntry.timestamp)}
       </div>{detailHeader.bind}{//

--- a/client/src/main/scala/pme123/adapters/client/ProjectInfoDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/ProjectInfoDialog.scala
@@ -12,13 +12,13 @@ private[client] case class ProjectInfoDialog(projectInfo: ProjectInfo)
   // **************************
   @dom
   private[client] def showDetail(): Binding[HTMLElement] =
-    <div class="ui modal">
+    <div class="ui modal detailDialog">
       {detailHeader.bind}{//
       infoList.bind}{//
       versionList.bind}{//
       propTable("Project Properties", projectInfo.adapterProps).bind}{//
       propTable("Common Properties", projectInfo.commonProps).bind}
-    </div>
+      </div>
 
   // 2. level of abstraction
   // **************************

--- a/client/src/main/scala/pme123/adapters/client/ProjectInfoDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/ProjectInfoDialog.scala
@@ -16,8 +16,14 @@ private[client] case class ProjectInfoDialog(projectInfo: ProjectInfo)
       {detailHeader.bind}{//
       infoList.bind}{//
       versionList.bind}{//
-      propTable("Project Properties", projectInfo.adapterProps).bind}{//
-      propTable("Common Properties", projectInfo.commonProps).bind}
+      val projectProps = projectInfo.projectProps
+      propTable(s"Project Properties (${projectProps.key})", projectProps.props).bind}{//
+      val adapterProps = projectInfo.adapterProps
+      propTable(s"scala-adapters Properties (${adapterProps.key})", adapterProps.props).bind}{//
+      Constants(
+        projectInfo.additionalProps
+          .map(ap => propTable(s"Additional Properties (${ap.key})", ap.props)): _*)
+        .map(_.bind)}
       </div>
 
   // 2. level of abstraction

--- a/client/src/main/scala/pme123/adapters/client/SemanticUI.scala
+++ b/client/src/main/scala/pme123/adapters/client/SemanticUI.scala
@@ -19,6 +19,8 @@ object SemanticUI {
     def popup(params: js.Any*): SemanticJQuery = js.native
     def modal(params: js.Any*): SemanticJQuery = js.native
     def checkbox(params: js.Any*): SemanticJQuery = js.native
+    def form(params: js.Any*): SemanticJQuery = js.native
+
   }
 
   // Monkey patching JQuery with implicit conversion
@@ -30,5 +32,19 @@ object SemanticUI {
     case INFO => "blue info circle icon"
     case DEBUG => "grey info circle icon"
 
+  }
+
+  trait Form extends js.Object {
+    def fields: js.Object
+  }
+
+  trait Field extends js.Object {
+    def identifier: String
+    def rules: js.Array[Rule]
+  }
+
+  trait Rule extends js.Object {
+    def `type`: String
+    def prompt: js.UndefOr[String] = js.undefined
   }
 }

--- a/client/src/main/scala/pme123/adapters/client/SemanticUI.scala
+++ b/client/src/main/scala/pme123/adapters/client/SemanticUI.scala
@@ -6,6 +6,7 @@ import pme123.adapters.shared.LogLevel._
 
 import scala.language.implicitConversions
 import scala.scalajs.js
+import scala.scalajs.js.annotation.ScalaJSDefined
 
 /**
   *
@@ -34,15 +35,18 @@ object SemanticUI {
 
   }
 
+  @ScalaJSDefined
   trait Form extends js.Object {
     def fields: js.Object
   }
 
+  @ScalaJSDefined
   trait Field extends js.Object {
     def identifier: String
     def rules: js.Array[Rule]
   }
 
+  @ScalaJSDefined
   trait Rule extends js.Object {
     def `type`: String
     def prompt: js.UndefOr[String] = js.undefined

--- a/client/src/main/scala/pme123/adapters/client/UIStore.scala
+++ b/client/src/main/scala/pme123/adapters/client/UIStore.scala
@@ -80,6 +80,13 @@ object UIStore extends Logger {
     uiState.showLastResults.value = true
   }
 
+
+  def showRunJobDialog() {
+    info(s"UIStore: showRunJobDialog")
+    hideAllDialogs()
+    uiState.showRunJobDialog.value = true
+  }
+
   def hideProjectInfo() {
     info(s"UIStore: hide ProjectInfo")
     uiState.showProjectInfo.value = false
@@ -140,6 +147,7 @@ object UIStore extends Logger {
     uiState.showClients.value = false
     uiState.showLastResults.value = false
     uiState.showProjectInfo.value = false
+    uiState.showRunJobDialog.value = false
     uiState.logEntryDetail.value = None
   }
 }
@@ -155,6 +163,7 @@ case class UIState(logData: Vars[LogEntry] = Vars[LogEntry]()
                    , showJobs: Var[Boolean] = Var(false)
                    , showClients: Var[Boolean] = Var(false)
                    , showLastResults: Var[Boolean] = Var(false)
+                   , showRunJobDialog: Var[Boolean] = Var(false)
                    , allJobs: Vars[JobConfig] = Vars()
                    , selectedClientConfig: Var[Option[ClientConfig]] = Var(None)
                    , lastResults: Vars[JsValue] = Vars()

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoClient.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoClient.scala
@@ -77,7 +77,7 @@ object DemoClient
     override def fromJson(lastResult: JsValue): JsResult[JobResultsRow] =
       Json.fromJson[DemoResult](lastResult)
         .map(dr => JobResultsRow(
-          Seq(td(dr.name), tdImg(dr.imgUrl), tdDateTime(dr.created))))
+          Seq(td(dr.name), tdImg(ImageElem.urlFromImg(dr.img)), tdDateTime(dr.created))))
   }
 
 

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoClient.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoClient.scala
@@ -45,7 +45,6 @@ object DemoClient
     with Logger {
 
   LoggerConfig.factory = ConsoleLoggerFactory()
-
   // @JSExportTopLevel exposes this function with the defined name in Javascript.
   // this is called by the index.scala.html of the server.
   // the only connection that is not type-safe!
@@ -56,7 +55,8 @@ object DemoClient
       case CUSTOM_PAGE =>
         DemoClient(context, websocketPath).create()
       case JOB_PROCESS =>
-        JobProcessView(context, websocketPath).create()
+        val socket = ClientWebsocket(context)
+        JobProcessView(socket, context, websocketPath, DefaultRunJobDialog(socket)).create()
       case JOB_RESULTS =>
         JobResultsView(context
           , websocketPath

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoClient.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoClient.scala
@@ -56,7 +56,7 @@ object DemoClient
         DemoClient(context, websocketPath).create()
       case JOB_PROCESS =>
         val socket = ClientWebsocket(context)
-        JobProcessView(socket, context, websocketPath, DefaultRunJobDialog(socket)).create()
+        JobProcessView(socket, context, websocketPath, DemoRunJobDialog(socket)).create()
       case JOB_RESULTS =>
         JobResultsView(context
           , websocketPath

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoRunJobDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoRunJobDialog.scala
@@ -1,26 +1,45 @@
 package pme123.adapters.client.demo
 
-import com.thoughtworks.binding.Binding.Constants
 import com.thoughtworks.binding.{Binding, dom}
-import org.scalajs.dom.raw.{Event, HTMLElement}
+import org.scalajs.dom.UIEvent
+import org.scalajs.dom.raw.{Event, FileReader, HTMLElement}
 import org.scalajs.jquery.jQuery
-import pme123.adapters.client.SemanticUI.jq2semantic
+import play.api.libs.json.Json
+import pme123.adapters.client.SemanticUI.{Field, Form, Rule, jq2semantic}
 import pme123.adapters.client.{ClientWebsocket, RunJobDialog, UIStore}
 import pme123.adapters.shared.Logger
+import pme123.adapters.shared.demo.ImageUpload
 
-import scala.scalajs.js.timers.setTimeout
-
+import scala.scalajs.js
+import scala.scalajs.js.JSON
 
 case class DemoRunJobDialog(socket: ClientWebsocket)
   extends RunJobDialog
     with Logger {
+
+  val form: js.Object = new Form {
+    val fields = js.Dynamic.literal(
+      demoDescr = new Field {
+        val identifier: String = "demoDescr"
+        val rules: js.Array[Rule] = js.Array(new Rule {
+          val `type`: String = "empty"
+        })
+      },
+      demoImage = new Field {
+        val identifier: String = "demoImage"
+        val rules: js.Array[Rule] = js.Array(new Rule {
+          val `type`: String = "empty"
+        })
+      }
+    )
+  }
 
   @dom
   def create(): Binding[HTMLElement] = {
     val show = UIStore.uiState.showRunJobDialog.bind
     if (show) {
       info("Open DemoRunJobDialog")
-      <div class="ui modal">
+      <div class="ui modal detailDialog">
         {//
         demoHeader.bind}{//
         demoForm.bind}
@@ -40,22 +59,52 @@ case class DemoRunJobDialog(socket: ClientWebsocket)
   @dom
   private def demoForm: Binding[HTMLElement] = {
     <div class="content">
-      <div class="ui form">
+      <iframe style="display:none" onload={_: Event => initForm()}></iframe>
+      <form class="ui form">
         <div class="field">
           <label>Description</label>
-          <input type="text" name="description" placeholder="..."/>
+          <input type="text" id="demoDescr" placeholder="..."/>
         </div>
         <div class="field">
-          <label>Last Name</label>
-          <input type="text" name="last-name" placeholder="Last Name"/>
+          <input type="file" class="inputFile" id="demoImage" />
+
+          <label for="demoImage" class="ui button">
+            <i class="ui upload icon"></i>
+            Choose image
+          </label>
         </div>
 
         <button class="ui basic icon button"
                 onclick={_: Event =>
-                  socket.runAdapter()
+                  if (jQuery(".ui.form").form("is valid").asInstanceOf[Boolean]) {
+                    import scala.scalajs.js.typedarray.Uint8Array
+                    val reader = new FileReader()
+                    reader.readAsText(demoImage.files(0), "UTF-8")
+                    reader.onload = (_: UIEvent) => {
+                      socket.runAdapter(Some(Json.toJson(ImageUpload(demoDescr.value, s"${reader.result}"))))
+                    }
+
+                  }
+
                 }>Submit</button>
-      </div>
+      </form>
     </div>
+  }
+
+  private def fileUpload() = {
+
+  }
+
+
+  // this must be called after rendering!
+  private def initForm() = {
+
+
+    println(s"Correct Form: ${JSON.stringify(form)}")
+
+    jQuery(".ui.form").form(form)
+
+
   }
 
 

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoRunJobDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoRunJobDialog.scala
@@ -79,7 +79,7 @@ case class DemoRunJobDialog(socket: ClientWebsocket)
                   if (jQuery(".ui.form").form("is valid").asInstanceOf[Boolean]) {
                     import scala.scalajs.js.typedarray.Uint8Array
                     val reader = new FileReader()
-                    reader.readAsText(demoImage.files(0), "UTF-8")
+                    reader.readAsDataURL(demoImage.files(0))
                     reader.onload = (_: UIEvent) => {
                       socket.runAdapter(Some(Json.toJson(ImageUpload(demoDescr.value, s"${reader.result}"))))
                     }

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoRunJobDialog.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoRunJobDialog.scala
@@ -1,0 +1,62 @@
+package pme123.adapters.client.demo
+
+import com.thoughtworks.binding.Binding.Constants
+import com.thoughtworks.binding.{Binding, dom}
+import org.scalajs.dom.raw.{Event, HTMLElement}
+import org.scalajs.jquery.jQuery
+import pme123.adapters.client.SemanticUI.jq2semantic
+import pme123.adapters.client.{ClientWebsocket, RunJobDialog, UIStore}
+import pme123.adapters.shared.Logger
+
+import scala.scalajs.js.timers.setTimeout
+
+
+case class DemoRunJobDialog(socket: ClientWebsocket)
+  extends RunJobDialog
+    with Logger {
+
+  @dom
+  def create(): Binding[HTMLElement] = {
+    val show = UIStore.uiState.showRunJobDialog.bind
+    if (show) {
+      info("Open DemoRunJobDialog")
+      <div class="ui modal">
+        {//
+        demoHeader.bind}{//
+        demoForm.bind}
+      </div>
+    } else
+      <div></div>
+  }
+
+  // 2. level of abstraction
+  // **************************
+
+  @dom
+  private def demoHeader: Binding[HTMLElement] = <div class="header">
+    Needed Demo Content
+  </div>
+
+  @dom
+  private def demoForm: Binding[HTMLElement] = {
+    <div class="content">
+      <div class="ui form">
+        <div class="field">
+          <label>Description</label>
+          <input type="text" name="description" placeholder="..."/>
+        </div>
+        <div class="field">
+          <label>Last Name</label>
+          <input type="text" name="last-name" placeholder="Last Name"/>
+        </div>
+
+        <button class="ui basic icon button"
+                onclick={_: Event =>
+                  socket.runAdapter()
+                }>Submit</button>
+      </div>
+    </div>
+  }
+
+
+}

--- a/client/src/main/scala/pme123/adapters/client/demo/DemoUIStore.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/DemoUIStore.scala
@@ -17,7 +17,7 @@ object DemoUIStore {
 
     override def fromJson(lastResult: JsValue): JsResult[ImageElem] =
       Json.fromJson[DemoResult](lastResult)
-        .map(ImageElem)
+        .map(dr => ImageElem(dr))
   }
 
   def updateImageElems(lastResults: Seq[JsValue]): Seq[ImageElem] = {

--- a/client/src/main/scala/pme123/adapters/client/demo/ImageElem.scala
+++ b/client/src/main/scala/pme123/adapters/client/demo/ImageElem.scala
@@ -1,17 +1,24 @@
 package pme123.adapters.client.demo
 
 import com.thoughtworks.binding.{Binding, dom}
-import org.scalajs.dom.raw.HTMLElement
-import org.scalajs.dom.window
-import pme123.adapters.shared.demo.DemoResult
+import julienrf.json.derived
+import org.scalajs.dom.raw.{Blob, FileReader, HTMLElement, URL}
+import org.scalajs.dom.{UIEvent, window}
+import play.api.libs.json.{Json, OFormat}
+import pme123.adapters.shared.{JobConfig, Logger}
+import pme123.adapters.shared.demo.{DemoResult, ImageUpload}
+import pme123.adapters.shared.demo.DemoResult._
 
+import scala.scalajs.js
 import scala.util.Random
 
 case class ImageElem(demoResult: DemoResult) {
 
   @dom
-  lazy val imageElement: Binding[HTMLElement] =
-      <img style={randomImgStyle} src={demoResult.imgUrl}/>
+  lazy val imageElement: Binding[HTMLElement] = {
+
+      <img style={randomImgStyle} src={ImageElem.urlFromImg(demoResult.img)}/>
+  }
 
   private lazy val randomImgStyle: String = {
     val sHeight = window.screen.height.toInt
@@ -28,4 +35,24 @@ case class ImageElem(demoResult: DemoResult) {
        """.stripMargin
   }
 
+}
+
+object ImageElem extends Logger {
+  def urlFromImg(img: Either[ImgUrl, ImgData]): ImgUrl = {
+
+    img match {
+      case Left(url) =>
+        info(s"Image from URL: $url")
+        url
+      case Right(data) =>
+        info(s"Image from Data: $data")
+        val reader = new FileReader()
+        reader.readAsText(new Blob(js.Array(data.asInstanceOf[String])), "UTF-8")
+        reader.onload = (_: UIEvent) => {
+          val imgUrl = URL.createObjectURL(new Blob(js.Array(data.asInstanceOf[String])))
+          info(s"Image URL: $imgUrl")
+        }
+        "todo"
+    }
+  }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -17,7 +17,7 @@ object Settings {
   lazy val orgId = "pme123"
   lazy val orgHomepage = Some(new URL("https://github.com/pme123"))
   lazy val projectName = "scala-adapters"
-  lazy val projectV = "1.3.0"
+  lazy val projectV = "1.3.1"
 
   // main versions
   lazy val scalaV = "2.12.4"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -17,7 +17,7 @@ object Settings {
   lazy val orgId = "pme123"
   lazy val orgHomepage = Some(new URL("https://github.com/pme123"))
   lazy val projectName = "scala-adapters"
-  lazy val projectV = "1.2.1"
+  lazy val projectV = "1.3.0"
 
   // main versions
   lazy val scalaV = "2.12.4"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -17,7 +17,7 @@ object Settings {
   lazy val orgId = "pme123"
   lazy val orgHomepage = Some(new URL("https://github.com/pme123"))
   lazy val projectName = "scala-adapters"
-  lazy val projectV = "1.3.3"
+  lazy val projectV = "1.3.5"
 
   // main versions
   lazy val scalaV = "2.12.4"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -17,7 +17,7 @@ object Settings {
   lazy val orgId = "pme123"
   lazy val orgHomepage = Some(new URL("https://github.com/pme123"))
   lazy val projectName = "scala-adapters"
-  lazy val projectV = "1.3.1"
+  lazy val projectV = "1.3.3"
 
   // main versions
   lazy val scalaV = "2.12.4"

--- a/server/app/AdaptersModule.scala
+++ b/server/app/AdaptersModule.scala
@@ -1,6 +1,7 @@
 import com.google.inject.AbstractModule
 import play.api.libs.concurrent.AkkaGuiceSupport
 import pme123.adapters.server.control._
+import pme123.adapters.server.entity.AdaptersContext
 import slogging.{LoggerConfig, SLF4JLoggerFactory}
 
 class AdaptersModule extends AbstractModule with AkkaGuiceSupport {
@@ -18,5 +19,7 @@ class AdaptersModule extends AbstractModule with AkkaGuiceSupport {
 
     bind(classOf[ApplicationInitializer])
       .asEagerSingleton()
+
+    AdaptersContext.logSettings
   }
 }

--- a/server/app/DemoModule.scala
+++ b/server/app/DemoModule.scala
@@ -1,9 +1,10 @@
 import com.google.inject.AbstractModule
 import play.api.libs.concurrent.AkkaGuiceSupport
-import pme123.adapters.server.boundary.{AccessControl, NoAccessControl}
+import pme123.adapters.server.boundary.NoAccessControl
 import pme123.adapters.server.control.JobCreation
 import pme123.adapters.server.control.demo.DemoJobCreation
 import pme123.adapters.server.entity.demo.DemoAdapterContext
+import pme123.adapters.shared.AccessControl
 
 class DemoModule extends AbstractModule with AkkaGuiceSupport {
 

--- a/server/app/DemoModule.scala
+++ b/server/app/DemoModule.scala
@@ -3,6 +3,7 @@ import play.api.libs.concurrent.AkkaGuiceSupport
 import pme123.adapters.server.boundary.{AccessControl, NoAccessControl}
 import pme123.adapters.server.control.JobCreation
 import pme123.adapters.server.control.demo.DemoJobCreation
+import pme123.adapters.server.entity.demo.DemoAdapterContext
 
 class DemoModule extends AbstractModule with AkkaGuiceSupport {
 
@@ -15,6 +16,8 @@ class DemoModule extends AbstractModule with AkkaGuiceSupport {
     // you need to define the AccessControl
     bind(classOf[AccessControl])
       .to(classOf[NoAccessControl])
+
+    DemoAdapterContext.logSettings
 
   }
 }

--- a/server/app/pme123/adapters/server/boundary/Secured.scala
+++ b/server/app/pme123/adapters/server/boundary/Secured.scala
@@ -4,6 +4,7 @@ import javax.inject.Inject
 import play.Environment
 import play.api.Logger
 import play.api.mvc._
+import pme123.adapters.shared
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -27,7 +28,7 @@ trait Secured {
 
   def env: Environment
 
-  def accessControl: AccessControl
+  def accessControl: shared.AccessControl
 
   /**
     * Request action builder that allows to add authentication
@@ -71,20 +72,8 @@ trait Secured {
 
 }
 
-
-trait AccessControl {
-
-  /**
-    * A user is valid for authentication if:
-    * - is the 'importer' user
-    * - is a user with the 'admin' role
-    *
-    * @param user username
-    * @param pwd  plain password
-    * @return valid logged user for importing
-    */
-  def isValidUser(user: String, pwd: String): Boolean
-}
+@deprecated("Use pme123.adapters.sharedSharedAccessControl instead")
+trait AccessControl extends shared.AccessControl
 
 // no access control needed
 class NoAccessControl extends AccessControl {

--- a/server/app/pme123/adapters/server/boundary/Secured.scala
+++ b/server/app/pme123/adapters/server/boundary/Secured.scala
@@ -5,6 +5,7 @@ import play.Environment
 import play.api.Logger
 import play.api.mvc._
 import pme123.adapters.shared
+import pme123.adapters.shared.AccessControl
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -71,9 +72,6 @@ trait Secured {
   }
 
 }
-
-@deprecated("Use pme123.adapters.sharedSharedAccessControl instead")
-trait AccessControl extends shared.AccessControl
 
 // no access control needed
 class NoAccessControl extends AccessControl {

--- a/server/app/pme123/adapters/server/control/JobActor.scala
+++ b/server/app/pme123/adapters/server/control/JobActor.scala
@@ -49,10 +49,10 @@ class JobActor @Inject()(@Assisted jobConfig: JobConfig
     case si: SchedulerInfo =>
       projectInfo = projectInfo.copy(schedulerInfo = Some(si))
       sendToSubscriber(projectInfo)
-    case RunJob(user) =>
-      doRunJob(user)
+    case RunJob(user, payload) =>
+      doRunJob(user, payload)
     case RunJobFromScheduler(nextExecution) =>
-      doRunJob("From Scheduler")
+      doRunJob("From Scheduler", None)
       nextExecution()
     case msg: AdapterMsg =>
       sendToSubscriber(msg)
@@ -90,7 +90,7 @@ class JobActor @Inject()(@Assisted jobConfig: JobConfig
   }
 
   // called if a user runs the Adapter Process (Button)
-  private def doRunJob(user: String) = {
+  private def doRunJob(user: String, payload: Option[JsValue]) = {
     info(s"called runAdapter: $user")
     if (isRunning) // this should not happen as the button is disabled, if running
       warn("The adapter is running already!")
@@ -100,7 +100,7 @@ class JobActor @Inject()(@Assisted jobConfig: JobConfig
       sendToSubscriber(RunStarted)
       implicit val logServ: LogService = LogService(s"Run Job: ${jobConfig.webPath}", user, Some(self))
       logService = Some(logServ)
-      handleImportResult(jobProcess.runJob(user))
+      handleImportResult(jobProcess.runJob(user, payload))
     }
   }
 

--- a/server/app/pme123/adapters/server/control/JobProcess.scala
+++ b/server/app/pme123/adapters/server/control/JobProcess.scala
@@ -4,9 +4,9 @@ import akka.actor.ActorRef
 import akka.stream.Materializer
 import akka.util.Timeout
 import play.api.libs.json.JsValue
-import pme123.adapters.server.entity.AdaptersContext
+import pme123.adapters.server.entity.{AdaptersContext, AdaptersSettings}
 import pme123.adapters.server.entity.AdaptersContext.settings._
-import pme123.adapters.shared.{AdaptersContextProp, ProjectInfo}
+import pme123.adapters.shared.{AdaptersContextProp, AdaptersContextProps, ProjectInfo}
 import pme123.adapters.version.BuildInfo
 
 import scala.concurrent.duration._
@@ -33,16 +33,18 @@ trait JobProcess {
   def createInfo(): ProjectInfo
 
   protected def createInfo(projectVersion: String
-                           , adapterProps: Seq[AdaptersContextProp] = Nil
+                           , projectProps: AdaptersContextProps
                            , additionalVersions: Seq[AdaptersContextProp] = Nil
-                          ) =
+                           , additionalProps: Seq[AdaptersContextProps] = Nil
+                           ) =
     ProjectInfo(projectVersion
       , BuildInfo.version
       , BuildInfo.builtAtString
       , email
-      , adapterProps
-      , AdaptersContext.props
+      , projectProps
+      , AdaptersContextProps(AdaptersSettings.configPath, AdaptersContext.props)
       , additionalVersions
+      , additionalProps
     )
 }
 

--- a/server/app/pme123/adapters/server/control/JobProcess.scala
+++ b/server/app/pme123/adapters/server/control/JobProcess.scala
@@ -3,10 +3,12 @@ package pme123.adapters.server.control
 import akka.actor.ActorRef
 import akka.stream.Materializer
 import akka.util.Timeout
+import play.api.libs.json.JsValue
 import pme123.adapters.server.entity.AdaptersContext
 import pme123.adapters.server.entity.AdaptersContext.settings._
 import pme123.adapters.shared.{AdaptersContextProp, ProjectInfo}
 import pme123.adapters.version.BuildInfo
+
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -19,6 +21,10 @@ trait JobProcess {
   def email: String = adminMailRecipient
 
   implicit protected val timeout: Timeout = Timeout(1.second)
+
+  def runJob(user: String, payload: Option[JsValue])(implicit logService: LogService
+                                                     , jobActor: ActorRef): Future[LogService] =
+    runJob(user)
 
   def runJob(user: String)
             (implicit logService: LogService

--- a/server/app/pme123/adapters/server/control/StreamsHelper.scala
+++ b/server/app/pme123/adapters/server/control/StreamsHelper.scala
@@ -8,14 +8,13 @@ import play.api.libs.json._
 import play.api.libs.ws.WSResponse
 import play.mvc.Http.Status
 import pme123.adapters.server.control.http.{WebAccessForbiddenException, WebBadStatusException, WebNotAcceptableException, WebNotFoundException}
-import pme123.adapters.server.entity.{AdaptersException, JsonParseException}
+import pme123.adapters.server.entity.JsonParseException
 import pme123.adapters.shared.LogLevel.DEBUG
-import pme123.adapters.shared.{LogLevel, Logger}
+import pme123.adapters.shared.{AdaptersException, LogLevel, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
-import pme123.adapters.shared.AdaptersExtensions._
 
 /**
   * Created by pascal.mengelt on 11.10.2016.

--- a/server/app/pme123/adapters/server/control/demo/DemoProcess.scala
+++ b/server/app/pme123/adapters/server/control/demo/DemoProcess.scala
@@ -11,7 +11,7 @@ import pme123.adapters.server.control.JobActor.{ClientsChange, LastResult}
 import pme123.adapters.server.control.demo.DemoService.toISODateTimeString
 import pme123.adapters.server.control.{JobProcess, LogService}
 import pme123.adapters.server.entity.JsonParseException
-import pme123.adapters.server.entity.demo.DemoResults
+import pme123.adapters.server.entity.demo.{DemoAdapterContext, DemoAdapterSettings, DemoResults}
 import pme123.adapters.shared.LogLevel.{DEBUG, ERROR, INFO, WARN}
 import pme123.adapters.shared._
 import pme123.adapters.shared.demo.{DemoResult, ImageUpload}
@@ -26,7 +26,9 @@ trait DemoProcess
   def jobLabel: String
 
   def createInfo(): ProjectInfo = // same version as the adapters!
-    createInfo(pme123.adapters.version.BuildInfo.version)
+    createInfo(pme123.adapters.version.BuildInfo.version
+      , AdaptersContextProps(DemoAdapterSettings.configPath, DemoAdapterContext.props)
+    )
 
   def runJob(user: String)
             (implicit logService: LogService, jobActor: ActorRef): Future[LogService] =
@@ -51,7 +53,7 @@ trait DemoProcess
     }
   }
 
-  protected def handleImage(payload: Option[JsValue])(implicit logService: LogService)= {
+  protected def handleImage(payload: Option[JsValue])(implicit logService: LogService): List[DemoResult] = {
     payload.map(p => Json.fromJson[ImageUpload](p) match {
       case JsSuccess(iu, _) => iu
       case JsError(errors) =>

--- a/server/app/pme123/adapters/server/control/demo/DemoProcess.scala
+++ b/server/app/pme123/adapters/server/control/demo/DemoProcess.scala
@@ -1,45 +1,67 @@
 package pme123.adapters.server.control.demo
 
-import javax.inject.Inject
+import java.time.LocalDateTime
 
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.stream.Materializer
-import play.api.libs.json.Json
+import javax.inject.Inject
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 import pme123.adapters.server.control.JobActor.{ClientsChange, LastResult}
+import pme123.adapters.server.control.demo.DemoService.toISODateTimeString
 import pme123.adapters.server.control.{JobProcess, LogService}
+import pme123.adapters.server.entity.JsonParseException
 import pme123.adapters.server.entity.demo.DemoResults
 import pme123.adapters.shared.LogLevel.{DEBUG, ERROR, INFO, WARN}
 import pme123.adapters.shared._
-import pme123.adapters.shared.demo.DemoResult
+import pme123.adapters.shared.demo.{DemoResult, ImageUpload}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
-trait DemoProcess extends JobProcess {
+trait DemoProcess
+  extends JobProcess
+    with Logger {
 
   def jobLabel: String
 
   def createInfo(): ProjectInfo = // same version as the adapters!
     createInfo(pme123.adapters.version.BuildInfo.version)
 
-  // the process fakes some long taking tasks that logs its progress
   def runJob(user: String)
-            (implicit logService: LogService
-             , jobActor: ActorRef): Future[LogService] = {
+            (implicit logService: LogService, jobActor: ActorRef): Future[LogService] =
+    throw new UnsupportedOperationException("this is not supported by the Demo Job Process")
+
+  // the process fakes some long taking tasks that logs its progress
+  override def runJob(user: String, payload: Option[JsValue])
+                     (implicit logService: LogService, jobActor: ActorRef): Future[LogService] = {
     Future {
       logService.startLogging()
-     DemoService.results
+      DemoService.results
           .foreach(doSomeWork)
+      val handledImage = handleImage(payload)
 
       val results = if (Random.nextBoolean()) DemoService.results else DemoService.results.reverse
-      (jobActor ? LastResult(DemoResults(results)))
+      (jobActor ? LastResult(DemoResults(handledImage ++ results)))
         .map{
           case ClientsChange(clientConfigs) =>
             logService.info(s"The results of ${clientConfigs.size} Clients have changed: ${clientConfigs.map(_.requestIdent).mkString("(", ", ", ")")}.")
         }
       logService
     }
+  }
+
+  protected def handleImage(payload: Option[JsValue])(implicit logService: LogService)= {
+    payload.map(p => Json.fromJson[ImageUpload](p) match {
+      case JsSuccess(iu, _) => iu
+      case JsError(errors) =>
+        val errMsg = s"Problem parsing UploadImage: ${errors.map(e => s"${e._1} -> ${e._2}")}"
+        logService.error(errMsg)
+        throw JsonParseException(errMsg)
+    }).map { iu =>
+      logService.info(s"Image imported: ${iu.descr}")
+      DemoResult(iu.descr, Right(iu.imgData), toISODateTimeString(LocalDateTime.now()))
+    }.toList
   }
 
   protected def doSomeWork(dr: DemoResult)
@@ -49,11 +71,13 @@ trait DemoProcess extends JobProcess {
     val detail = List(None, Some(s"Details for $jobLabel $ll: ${dr.name}"), Some("shell_session_save_history () \n{ \n    shell_session_history_enable;\n    history -a;\n    if [ -f \"$SHELL_SESSION_HISTFILE_SHARED\" ] && [ ! -s \"$SHELL_SESSION_HISTFILE\" ]; then\n        echo -ne '\\n...copying shared history...';\n        ( umask 077;\n        /bin/cp \"$SHELL_SESSION_HISTFILE_SHARED\" \"$SHELL_SESSION_HISTFILE\" );\n    fi;\n    echo -ne '\\n...saving history...';\n    ( umask 077;\n    /bin/cat \"$SHELL_SESSION_HISTFILE_NEW\" >> \"$SHELL_SESSION_HISTFILE_SHARED\" );\n    ( umask 077;\n    /bin/cat \"$SHELL_SESSION_HISTFILE_NEW\" >> \"$SHELL_SESSION_HISTFILE\" );\n    : >|\"$SHELL_SESSION_HISTFILE_NEW\";\n    if [ -n \"$HISTFILESIZE\" ]; then\n        echo -n 'truncating history files...';\n        HISTFILE=\"$SHELL_SESSION_HISTFILE_SHARED\";\n        HISTFILESIZE=\"$HISTFILESIZE\";\n        HISTFILE=\"$SHELL_SESSION_HISTFILE\";\n        HISTFILESIZE=\"$size\";\n        HISTFILE=\"$SHELL_SESSION_HISTFILE_NEW\";\n    fi;\n    echo -ne '\\n...'\n}"))(Random.nextInt(3))
     logService.log(ll, s"Job: $jobLabel $ll: ${dr.name}", detail)
   }
+
 }
 
 class DemoJobProcess @Inject()()(implicit val mat: Materializer, val ec: ExecutionContext)
   extends DemoProcess {
   override def jobLabel: String = "Demo Job"
+
 }
 
 class DemoJobWithDefaultSchedulerActor @Inject()()(implicit val mat: Materializer, val ec: ExecutionContext)
@@ -66,12 +90,13 @@ class DemoJobWithoutSchedulerActor @Inject()()(implicit val mat: Materializer, v
   val jobLabel = "Demo Job without Scheduler"
 
   // send result on each step
-  override def runJob(user: String)
+  override def runJob(user: String, payload: Option[JsValue])
                      (implicit logService: LogService
              , jobActor: ActorRef): Future[LogService] = {
     Future {
       logService.startLogging()
       jobActor ? LastResult(DemoResults(Nil)) // reset last result
+      jobActor ? handleImage(payload).map(dr => LastResult(DemoResults(Seq(dr)), append = true))
 
       DemoService.results.foreach { dr =>
         doSomeWork(dr)

--- a/server/app/pme123/adapters/server/control/demo/DemoService.scala
+++ b/server/app/pme123/adapters/server/control/demo/DemoService.scala
@@ -3,12 +3,17 @@ package pme123.adapters.server.control.demo
 import java.time.LocalDateTime
 
 import pme123.adapters.server.entity.ISODateTimeHelper
+import pme123.adapters.server.entity.demo.DemoAdapterContext.settings
+import pme123.adapters.shared.Logger
 import pme123.adapters.shared.demo.DemoResult
 
 import scala.util.Random
 
 object DemoService
-  extends ISODateTimeHelper {
+  extends ISODateTimeHelper
+    with Logger {
+
+  info(s"Demo init $settings")
 
   lazy val results: Seq[DemoResult] =
     for {

--- a/server/app/pme123/adapters/server/control/demo/DemoService.scala
+++ b/server/app/pme123/adapters/server/control/demo/DemoService.scala
@@ -15,7 +15,7 @@ object DemoService
       i <- 2 to 3
       k <- 1 to 5
     } yield DemoResult(s"Image Gallery $i - $k"
-      , s"https://www.gstatic.com/webp/gallery$i/$k.png"
+      , Left(s"https://www.gstatic.com/webp/gallery$i/$k.png")
       , toISODateTimeString(LocalDateTime.now().minusHours(Random.nextInt(100))))
 
 

--- a/server/app/pme123/adapters/server/entity/AdaptersContext.scala
+++ b/server/app/pme123/adapters/server/entity/AdaptersContext.scala
@@ -146,9 +146,7 @@ class AdaptersContext(config: Config)
 }
 
 // default Configuration
-object AdaptersContext extends AdaptersContext(config()) {
-  AdaptersContext.logSettings
-}
+object AdaptersContext extends AdaptersContext(config())
 
 // this contains implicit conversions!
 trait AdaptersContextPropsImplicits

--- a/server/app/pme123/adapters/server/entity/AdaptersContext.scala
+++ b/server/app/pme123/adapters/server/entity/AdaptersContext.scala
@@ -156,22 +156,12 @@ trait AdaptersContextPropsImplicits
   def props: Seq[AdaptersContextProp]
 
   lazy val logSettings: Seq[LogEntry] =
-    props.map(printString)
+    props.map(_.asString(name))
       .map(info(_))
-
-  lazy val asString: String = props.map(printString).mkString("\n")
-
-  lazy val asHtml: String = "<LI>" + props.map(printString)
-    .mkString("</LI><LI>") + "</LI>"
 
   protected def pwd(value:String): String = "*" * value.length
 
-  private def printString(prop: AdaptersContextProp): String =
-    propString(prop.key, prop.value)
-
-  private def propString(label: String, value: Any) =
-    s"${name.toUpperCase} '$label' >> $value"
-
+  lazy val asString: String = props.map(_.asString(name)).mkString("\n")
 
   implicit def fromAny(bool: Boolean): String = bool.toString
 

--- a/server/app/pme123/adapters/server/entity/AdaptersException.scala
+++ b/server/app/pme123/adapters/server/entity/AdaptersException.scala
@@ -1,26 +1,13 @@
 package pme123.adapters.server.entity
 
+import pme123.adapters.shared
+
 /**
   * Marker trait for all internal Exceptions, that are handled.
   * Created by pascal.mengelt on 09.08.2016.
   */
 trait AdaptersException
-  extends RuntimeException {
-  def msg: String
-
-  def cause: Option[Throwable] = None
-
-  override def getMessage: String = msg
-
-  override def getCause: Throwable = {
-    cause.orNull
-  }
-}
-
-object AdaptersException {
-
-
-}
+  extends shared.AdaptersException
 
 case class JsonParseException(msg: String, override val cause: Option[Throwable] = None)
   extends AdaptersException {

--- a/server/app/pme123/adapters/server/entity/demo/DemoAdapterContext.scala
+++ b/server/app/pme123/adapters/server/entity/demo/DemoAdapterContext.scala
@@ -1,0 +1,68 @@
+package pme123.adapters.server.entity.demo
+
+import com.typesafe.config.{Config, ConfigFactory}
+import pme123.adapters.server.entity.AdaptersContextPropsImplicits
+import pme123.adapters.shared.AdaptersContextProp
+
+/**
+  * created by pascal.mengelt
+  * This config uses the small framework typesafe-config.
+  * See here the explanation: https://github.com/typesafehub/config
+  * The configuration can be overridden direct in distribution:
+  *  - ${DIST_BASE}/conf/demo.conf
+  * see here the base: http://stackoverflow.com/questions/6201349/how-to-read-properties-file-placed-outside-war
+  *
+  * The defaults are described in reference.conf
+  */
+object DemoAdapterSettings {
+  val configPath = "demo.adapters"
+
+  val helloProp = s"hello"
+  val numberProp = s"number"
+  val passwordProp = s"password"
+  val titleShortProp = s"title.short"
+  val titleLongProp = s"title.long"
+
+  def config(): Config = ConfigFactory.load()
+
+}
+
+// this settings will be validated on startup
+class DemoAdapterSettings(config: Config) {
+
+  import DemoAdapterSettings._
+
+  // checkValid(), just as in the plain SimpleLibContext
+  config.checkValid(ConfigFactory.defaultReference(), configPath)
+  val projConfig = config.getConfig(configPath)
+
+  val hello: String = projConfig.getString(helloProp)
+  val number: Int = projConfig.getInt(numberProp)
+  val password: String = projConfig.getString(passwordProp)
+  val titleShort: String = projConfig.getString(titleShortProp)
+  val titleLong: String = projConfig.getString(titleLongProp)
+}
+
+// This is a different way to do DemoAdapterContext, using the
+// DemoAdapterSettings class to encapsulate and validate the
+// settings on startup
+class DemoAdapterContext(val config: Config)
+  extends AdaptersContextPropsImplicits {
+import DemoAdapterSettings._
+  val name = "demo"
+
+  val settings = new DemoAdapterSettings(config)
+
+  lazy val props: Seq[AdaptersContextProp] = {
+    Seq(
+      AdaptersContextProp(helloProp, settings.hello)
+      , AdaptersContextProp(numberProp, settings.number) // to string by AdaptersContextPropsImplicits
+      , AdaptersContextProp(passwordProp, pwd(settings.password)) // make password invisible
+      , AdaptersContextProp(titleShortProp, settings.titleShort)
+      , AdaptersContextProp(titleLongProp, settings.titleLong)
+    )
+  }
+}
+
+// default Configuration
+object DemoAdapterContext extends DemoAdapterContext(DemoAdapterSettings.config())

--- a/server/app/pme123/adapters/server/entity/demo/DemoAdapterContext.scala
+++ b/server/app/pme123/adapters/server/entity/demo/DemoAdapterContext.scala
@@ -48,7 +48,9 @@ class DemoAdapterSettings(config: Config) {
 // settings on startup
 class DemoAdapterContext(val config: Config)
   extends AdaptersContextPropsImplicits {
-import DemoAdapterSettings._
+
+  import DemoAdapterSettings._
+
   val name = "demo"
 
   val settings = new DemoAdapterSettings(config)

--- a/server/app/pme123/adapters/server/entity/demo/DemoResults.scala
+++ b/server/app/pme123/adapters/server/entity/demo/DemoResults.scala
@@ -16,7 +16,7 @@ case class DemoResults(results: Seq[DemoResult])
 
     def doFilter(filterable: DemoResult)(implicit filters: Map[String, String]): Boolean = {
       matchText("name", filterable.name) &&
-        matchText("imgUrl", filterable.imgUrl) &&
+        matchText("imgUrl", s"${if(filterable.img.isLeft) filterable.img.left else filterable.img.right}") &&
         matchDate(dateTimeAfterL, filterable.created, (a, b) => a <= b) &&
         matchDate(dateTimeBeforeL, filterable.created, (a, b) => a >= b)
     }

--- a/server/conf/demo.conf
+++ b/server/conf/demo.conf
@@ -39,3 +39,11 @@ pme123.adapters {
 
   wsocket.hosts.allowed = ["http://localhost:9000","http://localhost:5000", "ws://localhost:19001", "/" , "https://tranquil-reef-73468.herokuapp.com", "wss://tranquil-reef-73468.herokuapp.com"]
 }
+
+demo.adapters {
+  hello = "Hello Demo"
+  number = 42
+  password = "pwd123"
+  title.short = "Demo Adapter"
+  title.long = "A Demo to demonstrate the main features of scala-adapters. "
+}

--- a/server/conf/reference.conf
+++ b/server/conf/reference.conf
@@ -138,7 +138,7 @@ pme123.adapters {
       // Default is one day (1440 minutes) - be aware 1 minute is the smallest period possible
       // - and it must be greater than the time the import takes!
       // make also sure that the period is so that the import is at always the same time of day.
-      interval.minutes = 2
+     // interval.minutes = 2
     }
   }, {
     ident = "demoJobWithDefaultScheduler"

--- a/server/public/stylesheets/main.css
+++ b/server/public/stylesheets/main.css
@@ -13,3 +13,17 @@
     max-width: 200px;
     max-height: 200px;
 }
+
+.detailDialog {
+    overflow-y: auto;
+    max-height: calc(100vh - 4em);
+}
+
+.inputFile {
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+}

--- a/shared/src/main/scala/pme123/adapters/shared/AccessControl.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/AccessControl.scala
@@ -1,0 +1,18 @@
+package pme123.adapters.shared
+
+/**
+  * interface for a secured access to the boundary.
+  * At the moment only 'username' - 'password' is supported.
+  */
+trait AccessControl {
+  /**
+    * A user is valid for authentication if:
+    * - is the 'importer' user
+    * - is a user with the 'admin' role
+    *
+    * @param user username
+    * @param pwd  plain password
+    * @return valid logged user for importing
+    */
+  def isValidUser(user: String, pwd: String): Boolean
+}

--- a/shared/src/main/scala/pme123/adapters/shared/AdaptersContextProp.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/AdaptersContextProp.scala
@@ -6,6 +6,13 @@ import julienrf.json.derived
 import play.api.libs.json.OFormat
 import pme123.adapters.shared.JobConfig.JobIdent
 
+case class AdaptersContextProps(key: String, props: Seq[AdaptersContextProp])
+
+object AdaptersContextProps {
+  implicit val jsonFormat: OFormat[AdaptersContextProps] = derived.oformat[AdaptersContextProps]()
+
+}
+
 case class AdaptersContextProp(key: String, value: String)
 
 object AdaptersContextProp {

--- a/shared/src/main/scala/pme123/adapters/shared/AdaptersContextProp.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/AdaptersContextProp.scala
@@ -13,7 +13,15 @@ object AdaptersContextProps {
 
 }
 
-case class AdaptersContextProp(key: String, value: String)
+case class AdaptersContextProp(key: String, value: String) {
+
+  def asString(name: String): String =
+    propString(name)
+
+  def propString(name: String) =
+    s"${name.toUpperCase} '$key' >> $value"
+
+}
 
 object AdaptersContextProp {
   implicit val jsonFormat: OFormat[AdaptersContextProp] = derived.oformat[AdaptersContextProp]()

--- a/shared/src/main/scala/pme123/adapters/shared/AdaptersException.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/AdaptersException.scala
@@ -1,0 +1,18 @@
+package pme123.adapters.shared
+
+/**
+  * general exception to mark a handled exception
+  */
+trait AdaptersException
+  extends RuntimeException {
+  def msg: String
+
+  def cause: Option[Throwable] = None
+
+  override def getMessage: String = msg
+
+  override def getCause: Throwable = {
+    cause.orNull
+  }
+}
+

--- a/shared/src/main/scala/pme123/adapters/shared/SharedMessages.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/SharedMessages.scala
@@ -18,7 +18,7 @@ object AdapterMsg extends InstantHelper {
 
 // a client want's to start the Adapter process
 // you can trigger the next SchedulerInfo - if the RunAdapter was sent by the Scheduler
-case class RunJob(userName: String = "Anonymous")
+case class RunJob(userName: String = "Anonymous", payload: Option[JsValue] = None)
   extends AdapterMsg
 
 // the server indicates that the Adapter process is already running

--- a/shared/src/main/scala/pme123/adapters/shared/SharedMessages.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/SharedMessages.scala
@@ -45,9 +45,10 @@ case class ProjectInfo(projectVersion: String
                        , adaptersVersion: String
                        , buildTime: String
                        , adminMailRecipient: String
-                       , adapterProps: Seq[AdaptersContextProp]
-                       , commonProps: Seq[AdaptersContextProp]
+                       , projectProps: AdaptersContextProps
+                       , adapterProps: AdaptersContextProps
                        , additionalVersions: Seq[AdaptersContextProp] = Nil
+                       , additionalProps: Seq[AdaptersContextProps] = Nil
                        , lastExecution: Option[Instant] = None
                        , schedulerInfo: Option[SchedulerInfo] = None
                       ) extends AdapterMsg

--- a/shared/src/main/scala/pme123/adapters/shared/demo/DemoResult.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/demo/DemoResult.scala
@@ -1,10 +1,32 @@
 package pme123.adapters.shared.demo
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json._
 import pme123.adapters.shared.DateTimeString
 
-case class DemoResult(name: String, imgUrl: String, created: DateTimeString)
+case class DemoResult(name: String, img: Either[DemoResult.ImgData, DemoResult.ImgData], created: DateTimeString)
 
 object DemoResult {
+  type ImgUrl = String
+  type ImgData = String
   implicit val jsonFormat: OFormat[DemoResult] = Json.format[DemoResult]
+
+  implicit def eitherReads[A, B](implicit A: Reads[A], B: Reads[B]): Reads[Either[A, B]] =
+    Reads[Either[A, B]] { json =>
+      A.reads(json) match {
+        case JsSuccess(value, path) => JsSuccess(Left(value), path)
+        case JsError(e1) => B.reads(json) match {
+          case JsSuccess(value, path) => JsSuccess(Right(value), path)
+          case JsError(e2) => JsError(JsError.merge(e1, e2))
+        }
+      }
+    }
+
+  implicit def eitherWrites[A, B](implicit A: Writes[A], B: Writes[B]): Writes[Either[A,B]] =
+    Writes[Either[A, B]] {
+      case Left(a) => A.writes(a)
+      case Right(b) => B.writes(b)
+    }
+
+  implicit def eitherFormat[A, B](implicit A: Format[A], B: Format[B]): Format[Either[A,B]] =
+    Format(eitherReads, eitherWrites)
 }

--- a/shared/src/main/scala/pme123/adapters/shared/demo/ImageUpload.scala
+++ b/shared/src/main/scala/pme123/adapters/shared/demo/ImageUpload.scala
@@ -1,0 +1,11 @@
+package pme123.adapters.shared.demo
+
+import julienrf.json.derived
+import play.api.libs.json.OFormat
+
+case class ImageUpload(descr: String, imgData: String)
+
+object ImageUpload {
+  implicit val jsonFormat: OFormat[ImageUpload] = derived.oformat[ImageUpload]()
+
+}

--- a/shared/src/test/scala/pme123/adapters/shared/AdaptersExtensionsTest.scala
+++ b/shared/src/test/scala/pme123/adapters/shared/AdaptersExtensionsTest.scala
@@ -1,5 +1,8 @@
 package pme123.adapters.shared
 
+import org.scalatest.DoNotDiscover
+
+@DoNotDiscover
 class AdaptersExtensionsTest extends UnitTest {
 import AdaptersExtensions._
 


### PR DESCRIPTION
- Add possibility to infer with the run job to add additional content (form).
- moved AccessControl trait to shared (so it can be implemented also by libraries)
- moved AdaptersException to shared - so Supervision Strategy can be easily reused.